### PR TITLE
Removing hard coded credentials

### DIFF
--- a/src/firebaseConfig.js
+++ b/src/firebaseConfig.js
@@ -1,13 +1,13 @@
 import Firebase from 'firebase'
 
 var firebaseConfig = {
-    apiKey: "AIzaSyB6ITXlLyEe4fE6ae63hxKnRCI5ijPpucs",
-    authDomain: "austin-pizza.firebaseapp.com",
-    databaseURL: "https://austin-pizza.firebaseio.com",
-    projectId: "austin-pizza",
-    storageBucket: "",
-    messagingSenderId: "357633493417",
-    appId: "1:357633493417:web:d5d0b7666826ada2d79cb8"
+    apiKey: process.env.FIREBASE_API_KEY,
+    authDomain: process.env.FIREBASE_AUTH_DOMAIN,
+    databaseURL: process.env.FIREBASE_DB_HOST,
+    projectId: procdess.env.FIREBASE_PROJECT_ID,
+    storageBucket: process.env.FIREBASE_STORAGE_BUCKET || "",
+    messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
+    appId: process.env.FIREBASE_APP_ID
   };
 const firebaseApp = Firebase.initializeApp(firebaseConfig);
 const db = firebaseApp.database();


### PR DESCRIPTION
Don't hardcode your credentials in a public repository. Everyone can access your fireStore config with this.